### PR TITLE
Output topic name from ARM template

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,6 @@
 # name of the topic
 output "name" {
-  value = "${var.name}"
+  value = "${azurerm_template_deployment.topic.outputs["topicName"]}"
 }
 
 # primary connection string for send and listen operations

--- a/template/topic_template.json
+++ b/template/topic_template.json
@@ -54,6 +54,10 @@
     }
   ],
   "outputs": {
+    "topicName": {
+      "type": "string",
+      "value": "[parameters('serviceBusTopicName')]"
+    },
     "primarySendAndListenConnectionString": {
       "type": "string",
       "value": "[listkeys(variables('sendAndListenAuthRuleResourceId'), variables('sbVersion')).primaryConnectionString]"


### PR DESCRIPTION
Output topic name from ARM template instead of input variable.

Terraform is too smart and doesn't wait for modules to complete if the output is available earlier.