### PR TITLE
Make max message size for queue configurable for topic  module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ resource "azurerm_servicebus_topic" "servicebus_topic" {
   support_ordering                        = var.support_ordering
   auto_delete_on_idle                     = var.auto_delete_on_idle
   enable_express                          = var.enable_express
+  max_message_size_in_kilobytes           = var.max_message_size_in_kilobytes
 }
 
 resource "azurerm_servicebus_topic_authorization_rule" "send_listen_auth_rule" {

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,9 @@ variable "enable_express" {
   default     = false
   description = "Enable express"
 }
+
+variable "max_message_size_in_kilobytes" {
+  type        = string
+  description = "Integer value which controls the maximum size of a message allowed on the topic for Premium SKU"
+  default     = "1024"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-153

### Change description ###

-  In SSCS we are seeing our callback orchestrator fails to post messages on the topic as they sometimes exceeds 1MB limit. 
- Although we don't want to post such large data on the queue in the short term we want to increase the size slightly till we have strategic fix otherwise it keeps failing and takes lot of effort and time to resolve it manually.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
