### PR TITLE
Default max_message_size to null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -70,5 +70,5 @@ variable "enable_express" {
 variable "max_message_size_in_kilobytes" {
   type        = string
   description = "Integer value which controls the maximum size of a message allowed on the topic for Premium SKU"
-  default     = "1024"
+  default     = null
 }


### PR DESCRIPTION
only supported on premium sku

